### PR TITLE
Cleanup form components and mutations a little

### DIFF
--- a/src/components/Contexts/Variables/Modals/Instrument.tsx
+++ b/src/components/Contexts/Variables/Modals/Instrument.tsx
@@ -107,7 +107,6 @@ export function Instrument() {
         <div className="selectors">
           <span>Instrument</span>
           <Dropdown
-            disabled={false}
             value={name}
             options={nameOptions}
             onChange={(e) => setName(e.target.value)}

--- a/src/components/Contexts/Variables/Modals/SlewFlags.tsx
+++ b/src/components/Contexts/Variables/Modals/SlewFlags.tsx
@@ -58,6 +58,12 @@ function SlewFlagInput<T extends keyof UpdateSlewFlagsMutationVariables>({
         pk: flags.pk,
         [flag]: !flags[flag],
       },
+      optimisticResponse: {
+        updateSlewFlags: {
+          ...flags,
+          [flag]: !flags[flag],
+        },
+      },
     });
   }
   const inputId = `${flag}-${id}`;

--- a/src/components/Contexts/Variables/Modals/Target.tsx
+++ b/src/components/Contexts/Variables/Modals/Target.tsx
@@ -84,19 +84,20 @@ export function Target() {
       }
     >
       <div className="target-edit">
-        <span style={{ gridArea: 's1' }} className="label">
+        <label htmlFor="targetName" style={{ gridArea: 's1' }} className="label">
           Name
-        </span>
+        </label>
         <InputText
-          disabled={false}
+          id="targetName"
           style={{ gridArea: 's2' }}
           value={auxTarget.name ?? ''}
           onChange={(e) => setAuxTarget({ ...auxTarget, name: e.target.value })}
         />
-        <span style={{ gridArea: 'l1' }} className="label">
+        <label htmlFor="coordsType" style={{ gridArea: 'l1' }} className="label">
           Coordinates
-        </span>
+        </label>
         <Dropdown
+          inputId="coordsType"
           disabled={!isBaseTarget(auxTarget)}
           style={{ gridArea: 'd1' }}
           value={coordsType}
@@ -145,11 +146,11 @@ export function Target() {
           }}
           placeholder="Select coordinates type"
         />
-        <span style={{ gridArea: 't1' }} className="label">
+        <label htmlFor="raAzDegrees" style={{ gridArea: 't1' }} className="label">
           {coordsType === 'celestial' ? 'RA' : 'Az'}
-        </span>
+        </label>
         <InputNumber
-          disabled={false}
+          inputId="raAzDegrees"
           style={{ gridArea: 'c11' }}
           value={coordsType === 'celestial' ? auxTarget.ra?.degrees : auxTarget.az?.degrees}
           onValueChange={(e) => {
@@ -182,11 +183,11 @@ export function Target() {
             }
           }}
         />
-        <span style={{ gridArea: 'f11' }} className="label">
+        <label htmlFor="raAzDegrees" style={{ gridArea: 'f11' }} className="label">
           degrees
-        </span>
+        </label>
         <InputText
-          disabled={false}
+          id="raAzHmsDms"
           style={{ gridArea: 'c12' }}
           value={c1String}
           onChange={(e) => {
@@ -204,14 +205,14 @@ export function Target() {
             setc1String(e.target.value);
           }}
         />
-        <span style={{ gridArea: 'f12' }} className="label">
+        <label htmlFor="raAzHmsDms" style={{ gridArea: 'f12' }} className="label">
           {coordsType === 'celestial' ? 'hms' : 'dms'}
-        </span>
-        <span style={{ gridArea: 't2' }} className="label">
+        </label>
+        <label htmlFor="decElDegrees" style={{ gridArea: 't2' }} className="label">
           {coordsType === 'celestial' ? 'Dec' : 'El'}
-        </span>
+        </label>
         <InputNumber
-          disabled={false}
+          inputId="decElDegrees"
           style={{ gridArea: 'c21' }}
           value={coordsType === 'celestial' ? auxTarget.dec?.degrees : auxTarget.el?.degrees}
           onValueChange={(e) => {
@@ -242,11 +243,11 @@ export function Target() {
             }
           }}
         />
-        <span style={{ gridArea: 'f21' }} className="label">
+        <label htmlFor="decElDegrees" style={{ gridArea: 'f21' }} className="label">
           degrees
-        </span>
+        </label>
         <InputText
-          disabled={false}
+          id="decElDms"
           style={{ gridArea: 'c22' }}
           value={c2String}
           onChange={(e) => {
@@ -264,14 +265,14 @@ export function Target() {
             setc2String(e.target.value);
           }}
         />
-        <span style={{ gridArea: 'f22' }} className="label">
+        <label htmlFor="decElDms" style={{ gridArea: 'f22' }} className="label">
           dms
-        </span>
-        <span style={{ gridArea: 's3' }} className="label">
+        </label>
+        <label htmlFor="targetEpoch" style={{ gridArea: 's3' }} className="label">
           Epoch
-        </span>
+        </label>
         <InputText
-          disabled={auxTarget.type === 'FIXED'}
+          id="targetEpoch"
           style={{ gridArea: 's4' }}
           value={(auxTarget.type === 'FIXED' ? '' : auxTarget.epoch) ?? ''}
           onChange={(e) => setAuxTarget({ ...auxTarget, epoch: e.target.value })}

--- a/src/components/Panels/Guider/Alarms/Alarms.tsx
+++ b/src/components/Panels/Guider/Alarms/Alarms.tsx
@@ -15,10 +15,10 @@ export function Alarms() {
   const { data, loading: subscriptionLoading } = useGuideQualities();
   const guideQualities = data?.guidersQualityValues;
 
-  const { data: alarmsData, loading: alarmsLoading, updateQuery } = useGuideAlarms();
+  const { data: alarmsData, loading: alarmsLoading } = useGuideAlarms();
   const alarms = alarmsData?.guideAlarms;
 
-  const [updateAlarm] = useUpdateGuideAlarm();
+  const [updateAlarm, { loading: updateLoading }] = useUpdateGuideAlarm();
 
   useEffect(() => {
     const hasAlarm =
@@ -34,13 +34,10 @@ export function Alarms() {
   function onUpdateAlarm(variables: UpdateGuideAlarmMutationVariables) {
     updateAlarm({
       variables,
-      onCompleted(data) {
-        updateQuery((prev) => ({ guideAlarms: { ...prev.guideAlarms, [variables.wfs]: data.updateGuideAlarm } }));
-      },
     });
   }
 
-  const disabled = !canEdit || subscriptionLoading || alarmsLoading;
+  const disabled = !canEdit || subscriptionLoading || alarmsLoading || updateLoading;
 
   return (
     <div className="alarms">

--- a/src/components/Panels/Guider/Loop/AdaptiveOptics.tsx
+++ b/src/components/Panels/Guider/Loop/AdaptiveOptics.tsx
@@ -22,6 +22,12 @@ export function Altair() {
           pk: state.pk,
           [name]: value,
         },
+        optimisticResponse: {
+          updateAltairGuideLoop: {
+            ...state,
+            [name]: value,
+          },
+        },
       });
   }
 
@@ -31,50 +37,74 @@ export function Altair() {
     <div className="adaptive-optics">
       <Title title="Altair" />
       <div className="ao-body">
-        <span className="label">AO enabled</span>
+        <label htmlFor="aoEnabled" className="label">
+          AO enabled
+        </label>
         <Checkbox
+          inputId="aoEnabled"
           disabled={disabled}
           checked={!!state?.aoEnabled}
           onChange={() => modifyAltairGuideLoop('aoEnabled', !state?.aoEnabled)}
         />
-        <span className="label">OI blend</span>
+        <label htmlFor="oiBlend" className="label">
+          OI blend
+        </label>
         <Checkbox
+          inputId="oiBlend"
           disabled={disabled}
           checked={!!state?.oiBlend}
           onChange={() => modifyAltairGuideLoop('oiBlend', !state?.oiBlend)}
         />
-        <span className="label">Focus</span>
+        <label htmlFor="focus" className="label">
+          Focus
+        </label>
         <Checkbox
+          inputId="focus"
           disabled={disabled}
           checked={!!state?.focus}
           onChange={() => modifyAltairGuideLoop('focus', !state?.focus)}
         />
-        <span className="label">P1 TTF</span>
+        <label htmlFor="p1Ttf" className="label">
+          P1 TTF
+        </label>
         <Checkbox
+          inputId="p1Ttf"
           disabled={disabled}
           checked={!!state?.p1Ttf}
           onChange={() => modifyAltairGuideLoop('p1Ttf', !state?.p1Ttf)}
         />
-        <span className="label">STRAP</span>
+        <label htmlFor="strap" className="label">
+          STRAP
+        </label>
         <Checkbox
+          inputId="strap"
           disabled={disabled}
           checked={!!state?.strap}
           onChange={() => modifyAltairGuideLoop('strap', !state?.strap)}
         />
-        <span className="label">OI TTF</span>
+        <label htmlFor="oiTtf" className="label">
+          OI TTF
+        </label>
         <Checkbox
+          inputId="oiTtf"
           disabled={disabled}
           checked={!!state?.oiTtf}
           onChange={() => modifyAltairGuideLoop('oiTtf', !state?.oiTtf)}
         />
-        <span className="label">TTGS</span>
+        <label htmlFor="ttgs" className="label">
+          TTGS
+        </label>
         <Checkbox
+          inputId="ttgs"
           disabled={disabled}
           checked={!!state?.ttgs}
           onChange={() => modifyAltairGuideLoop('ttgs', !state?.ttgs)}
         />
-        <span className="label">SFO</span>
+        <label htmlFor="sfo" className="label">
+          SFO
+        </label>
         <Checkbox
+          inputId="sfo"
           disabled={disabled}
           checked={!!state?.sfo}
           onChange={() => modifyAltairGuideLoop('sfo', !state?.sfo)}
@@ -100,6 +130,12 @@ export function GeMS() {
           pk: state.pk,
           [name]: value,
         },
+        optimisticResponse: {
+          updateGemsGuideLoop: {
+            ...state,
+            [name]: value,
+          },
+        },
       });
   }
 
@@ -109,38 +145,53 @@ export function GeMS() {
     <div className="adaptive-optics">
       <Title title="GeMS" />
       <div className="ao-body">
-        <span className="label">AO enabled</span>
+        <label htmlFor="aoEnabled" className="label">
+          AO enabled
+        </label>
         <Checkbox
+          inputId="aoEnabled"
           disabled={disabled}
           checked={!!state?.aoEnabled}
           onChange={() => modifyGemsGuideLoop('aoEnabled', !state?.aoEnabled)}
         />
-        <span className="label">Focus</span>
+        <label className="label">Focus</label>
         <Checkbox
           disabled={disabled}
           checked={!!state?.focus}
           onChange={() => modifyGemsGuideLoop('focus', !state?.focus)}
         />
-        <span className="label">Rotation</span>
+        <label htmlFor="rotation" className="label">
+          Rotation
+        </label>
         <Checkbox
+          inputId="rotation"
           disabled={disabled}
           checked={!!state?.rotation}
           onChange={() => modifyGemsGuideLoop('rotation', !state?.rotation)}
         />
-        <span className="label">Tip/Tilt</span>
+        <label htmlFor="tipTilt" className="label">
+          Tip/Tilt
+        </label>
         <Checkbox
+          inputId="tipTilt"
           disabled={disabled}
           checked={!!state?.tipTilt}
           onChange={() => modifyGemsGuideLoop('tipTilt', !state?.tipTilt)}
         />
-        <span className="label">Anisopl.</span>
+        <label htmlFor="anisopl" className="label">
+          Anisopl.
+        </label>
         <Checkbox
+          inputId="anisopl"
           disabled={disabled}
           checked={!!state?.anisopl}
           onChange={() => modifyGemsGuideLoop('anisopl', !state?.anisopl)}
         />
-        <span className="label">Flexure</span>
+        <label htmlFor="flexure" className="label">
+          Flexure
+        </label>
         <Checkbox
+          inputId="flexure"
           disabled={disabled}
           checked={!!state?.flexure}
           onChange={() => modifyGemsGuideLoop('flexure', !state?.flexure)}

--- a/src/components/Panels/Guider/Loop/Configuration.tsx
+++ b/src/components/Panels/Guider/Loop/Configuration.tsx
@@ -14,9 +14,10 @@ import { ReactNode } from 'react';
 
 export function Configuration() {
   const canEdit = useCanEdit();
-  const configuration = useConfiguration().data?.configuration;
-  const { data, updateQuery, loading: getLoading } = useGetGuideLoop();
+  const { data: confData, loading: getConfLoading } = useConfiguration();
+  const { data, loading: getLoading } = useGetGuideLoop();
 
+  const configuration = confData?.configuration;
   const state =
     data?.guideLoop ??
     ({
@@ -25,8 +26,8 @@ export function Configuration() {
     } as GuideLoop);
 
   const [updateGuideLoop, { loading: updateLoading }] = useUpdateGuideLoop();
-  const guideEnable = useGuideEnable();
-  const guideDisable = useGuideDisable();
+  const [guideEnable, { loading: enableLoading }] = useGuideEnable();
+  const [guideDisable, { loading: disableLoading }] = useGuideDisable();
 
   function modifyGuideLoop<T extends keyof UpdateGuideLoopMutationVariables>(
     name: T,
@@ -38,8 +39,11 @@ export function Configuration() {
           pk: state.pk,
           [name]: value,
         },
-        onCompleted(data) {
-          updateQuery(() => ({ guideLoop: data.updateGuideLoop }));
+        optimisticResponse: {
+          updateGuideLoop: {
+            ...(state as GuideLoop),
+            [name]: value,
+          },
         },
       });
   }
@@ -80,22 +84,29 @@ export function Configuration() {
     }
   }
 
-  const disabled = !canEdit || getLoading || updateLoading;
+  const disabled = !canEdit;
+  const loading = getLoading || getConfLoading || updateLoading;
 
   return (
     <>
       <div className="configuration">
         <div className="body">
-          <span className="label" style={{ gridArea: 'l1' }}>
+          <label
+            htmlFor={state.m2TipTiltEnable ? 'm2TipTiltSource' : 'm2TipTiltEnable'}
+            className="label"
+            style={{ gridArea: 'l1' }}
+          >
             M2 Tip/Tilt
-          </span>
+          </label>
           <Checkbox
+            inputId="m2TipTiltEnable"
             style={{ gridArea: 's1' }}
-            disabled={disabled}
+            disabled={disabled || loading}
             checked={state.m2TipTiltEnable}
             onChange={() => modifyGuideLoop('m2TipTiltEnable', !state.m2TipTiltEnable)}
           />
           <MultiSelect
+            inputId="m2TipTiltSource"
             value={state.m2TipTiltSource?.split(',') ?? ''}
             onChange={(e) => modifyGuideLoop('m2TipTiltSource', (e.value as string[]).join(','))}
             options={[
@@ -110,20 +121,27 @@ export function Configuration() {
             showSelectAll={false}
             style={{ gridArea: 'd1' }}
             disabled={disabled || !state.m2TipTiltEnable}
+            loading={loading}
           />
           <div className="lever" onClick={() => modifyGuideLoop('m2TipTiltFocusLink', !state.m2TipTiltFocusLink)}>
             {state.m2TipTiltFocusLink ? <ConnectedChain /> : <BrokenChain />}
           </div>
-          <span className="label" style={{ gridArea: 'l2' }}>
+          <label
+            htmlFor={state.m2FocusEnable && !state.m2TipTiltFocusLink ? 'm2FocusSource' : 'm2FocusEnable'}
+            className="label"
+            style={{ gridArea: 'l2' }}
+          >
             M2 Focus
-          </span>
+          </label>
           <Checkbox
+            inputId="m2FocusEnable"
             style={{ gridArea: 's2' }}
-            disabled={disabled}
+            disabled={disabled || loading}
             checked={state.m2FocusEnable}
             onChange={() => modifyGuideLoop('m2FocusEnable', !state.m2FocusEnable)}
           />
           <MultiSelect
+            inputId="m2FocusSource"
             value={
               state.m2TipTiltFocusLink
                 ? state.m2TipTiltSource
@@ -146,57 +164,70 @@ export function Configuration() {
             showSelectAll={false}
             style={{ gridArea: 'd2' }}
             disabled={disabled || state.m2TipTiltFocusLink || !state.m2FocusEnable}
+            loading={loading}
           />
-          <span className="label" style={{ gridArea: 'l3' }}>
+          <label
+            htmlFor={state.m2ComaEnable ? 'm2ComaM1CorrectionsSource' : 'm2ComaEnable'}
+            className="label"
+            style={{ gridArea: 'l3' }}
+          >
             M2 Coma
-          </span>
+          </label>
           <Checkbox
-            disabled={disabled}
+            inputId="m2ComaEnable"
+            disabled={disabled || loading}
             checked={state.m2ComaEnable}
             onChange={() => modifyGuideLoop('m2ComaEnable', !state.m2ComaEnable)}
           />
           <Dropdown
+            inputId="m2ComaM1CorrectionsSource"
             style={{ gridArea: 'd3' }}
             disabled={disabled || (!state.m2ComaEnable && !state.m1CorrectionsEnable)}
+            loading={loading}
             value={state.m2ComaM1CorrectionsSource}
             // options={["PWFS1", "PWFS2", "PWFS1 & PWFS2", "OIWFS", "GAOS"]}
             options={['OIWFS']}
             onChange={(e) => modifyGuideLoop('m2ComaM1CorrectionsSource', e.target.value)}
             placeholder="Select a source"
           />
-          <span className="label" style={{ gridArea: 'l4' }}>
+          <label htmlFor="m1CorrectionsEnable" className="label" style={{ gridArea: 'l4' }}>
             M1 Corrections
-          </span>
+          </label>
           <Checkbox
+            inputId="m1CorrectionsEnable"
             style={{ gridArea: 's4' }}
-            disabled={disabled}
+            disabled={disabled || loading}
             checked={state.m1CorrectionsEnable}
             onChange={() => modifyGuideLoop('m1CorrectionsEnable', !state.m1CorrectionsEnable)}
           />
-          <span className="label" style={{ gridArea: 'l5' }}>
+          <label htmlFor="mountOffload" className="label" style={{ gridArea: 'l5' }}>
             Mount offload
-          </span>
+          </label>
           <Checkbox
+            inputId="mountOffload"
             style={{ gridArea: 's5' }}
-            disabled={disabled}
+            disabled={disabled || loading}
             checked={state.mountOffload}
             onChange={() => modifyGuideLoop('mountOffload', !state.mountOffload)}
           />
-          <span className="label" style={{ gridArea: 'l6' }}>
+          <label htmlFor="daytimeMode" className="label" style={{ gridArea: 'l6' }}>
             Daytime mode
-          </span>
+          </label>
           <Checkbox
+            inputId="daytimeMode"
             style={{ gridArea: 's6' }}
-            disabled={disabled}
+            disabled={disabled || loading}
             checked={state.daytimeMode}
             onChange={() => modifyGuideLoop('daytimeMode', !state.daytimeMode)}
           />
-          <span className="label" style={{ gridArea: 'l7' }}>
+          <label htmlFor="probeTracking" className="label" style={{ gridArea: 'l7' }}>
             Probe tracking
-          </span>
+          </label>
           <Dropdown
+            inputId="probeTracking"
             style={{ gridArea: 'd7' }}
             disabled={disabled}
+            loading={loading}
             value={state.probeTracking}
             options={[
               'OI➡OI',
@@ -216,30 +247,18 @@ export function Configuration() {
         </div>
         <div className="buttons">
           <Button
-            disabled={disabled}
+            disabled={disabled || enableLoading || disableLoading}
             onClick={() =>
               void guideEnable({
                 variables: {
                   config: translateStateGuideInput(),
-                },
-                onCompleted() {
-                  // console.log(data)
                 },
               })
             }
           >
             Enable
           </Button>
-          <Button
-            disabled={disabled}
-            onClick={() =>
-              void guideDisable({
-                onCompleted() {
-                  // console.log(data)
-                },
-              })
-            }
-          >
+          <Button disabled={disabled || enableLoading || disableLoading} onClick={() => void guideDisable()}>
             Disable
           </Button>
         </div>

--- a/src/components/Panels/Telescope/Systems/AdaptiveOptics.tsx
+++ b/src/components/Panels/Telescope/Systems/AdaptiveOptics.tsx
@@ -25,6 +25,12 @@ export function GeMS({ canEdit }: { canEdit: boolean }) {
           pk: state.pk,
           [name]: value,
         },
+        optimisticResponse: {
+          updateGemsInstrument: {
+            ...state,
+            [name]: value,
+          },
+        },
       });
   }
 
@@ -68,6 +74,12 @@ export function Altair({ canEdit }: { canEdit: boolean }) {
         variables: {
           pk: state.pk,
           [name]: value,
+        },
+        optimisticResponse: {
+          updateAltairInstrument: {
+            ...state,
+            [name]: value,
+          },
         },
       });
   }

--- a/src/gql/server/GuideState.ts
+++ b/src/gql/server/GuideState.ts
@@ -28,9 +28,7 @@ const GUIDE_ENABLE = graphql(`
 `);
 
 export function useGuideEnable() {
-  const [mutationFunction] = useMutation(GUIDE_ENABLE);
-
-  return mutationFunction;
+  return useMutation(GUIDE_ENABLE);
 }
 
 const GUIDE_DISABLE = graphql(`
@@ -43,7 +41,5 @@ const GUIDE_DISABLE = graphql(`
 `);
 
 export function useGuideDisable() {
-  const [mutationFunction] = useMutation(GUIDE_DISABLE);
-
-  return mutationFunction;
+  return useMutation(GUIDE_DISABLE);
 }


### PR DESCRIPTION
- Use `<label>` elements instead of `<span>` for form labels
- Remove unused `disabled` props from form components
- Add `optimisticResponse` to mutations where it makes sense, to improve perceived performance
  - Where this is used, the components use the `loading` property from the mutations
- Remove `onCompleted` callbacks from mutations where they are not needed
- Add `loading` properties to components instead of `disabled` where appropriate
