### PR TITLE
Load URI's from environment file

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "codegen": "graphql-codegen --config tasks/codegen.ts",
     "prepare": "husky"
   },
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@apollo/client": "3.11.5",
     "clsx": "2.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
 import { ApolloProvider } from '@apollo/client';
 import { Modals } from '@Contexts/Variables/Modals/Modals';
-import { client } from '@gql/ApolloConfigs';
-import { useEffect } from 'react';
+import { createClient } from '@gql/ApolloConfigs';
+import { useEffect, useMemo } from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { useThemeValue } from './components/atoms/theme';
+import type { Environment } from './Helpers/environment';
 
 // Components
 import Home from './components/Layout/Home/Home';
@@ -17,7 +18,9 @@ const router = createBrowserRouter([
   { path: '/token', element: <Token /> },
 ]);
 
-export function App() {
+export function App({ environment }: { environment: Environment }) {
+  const client = useMemo(() => createClient(environment), [environment]);
+
   const theme = useThemeValue();
   // Re-render on theme change
   useEffect(() => {

--- a/src/Helpers/environment.ts
+++ b/src/Helpers/environment.ts
@@ -1,0 +1,12 @@
+import environments from '../assets/environments.json';
+
+export type Environment = (typeof environments)[0];
+
+const getEnvironmentForHost = (host: string) => environments.find((e) => e.hostName === host);
+
+export function getEnvironment(): Environment {
+  const env = getEnvironmentForHost(window.location.hostname) ?? getEnvironmentForHost('*')!;
+
+  console.log(`Loaded ${env.environment} environment`, env);
+  return env;
+}

--- a/src/assets/environments.json
+++ b/src/assets/environments.json
@@ -1,0 +1,26 @@
+[
+  {
+    "hostName": "*",
+    "environment": "LOCAL",
+    "navigateServerURI": "/navigate/graphql",
+    "navigateServerWsURI": "/navigate/ws",
+    "navigateConfigsURI": "/db",
+    "odbURI": "/odb"
+  },
+  {
+    "hostName": "navigate.hi.gemini.edu",
+    "environment": "Gemini North",
+    "navigateServerURI": "/navigate/graphql",
+    "navigateServerWsURI": "/navigate/ws",
+    "navigateConfigsURI": "/db",
+    "odbURI": "https://lucuma-postgres-odb-production.herokuapp.com/odb"
+  },
+  {
+    "hostName": "navigate.cl.gemini.edu",
+    "environment": "Gemini South",
+    "navigateServerURI": "/navigate/graphql",
+    "navigateServerWsURI": "/nagiate/ws",
+    "navigateConfigsURI": "/db",
+    "odbURI": "https://lucuma-postgres-odb-production.herokuapp.com/odb"
+  }
+]

--- a/src/gql/ApolloConfigs.ts
+++ b/src/gql/ApolloConfigs.ts
@@ -6,57 +6,55 @@ import { WebSocketLink } from '@apollo/client/link/ws';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
 import { getMainDefinition } from '@apollo/client/utilities';
 import { Kind, OperationTypeNode } from 'graphql/language';
+import { Environment } from '@/Helpers/environment';
 
-const navigateCommandServer = new HttpLink({
-  uri: import.meta.env.VITE_NG_SERVER_URI ?? 'http://navigate.lucuma.xyz:5173/navigate/graphql',
-});
+export function createClient(env: Environment) {
+  const navigateCommandServer = new HttpLink({ uri: env.navigateServerURI });
 
-const navigateConfigs = new HttpLink({
-  uri: import.meta.env.VITE_NG_CONFIGS_URI ?? 'http://navigate.lucuma.xyz:5173/db',
-});
+  const navigateConfigs = new HttpLink({ uri: env.navigateConfigsURI });
 
-const odbLink = new HttpLink({
-  uri: import.meta.env.VITE_ODB_URI ?? 'https://lucuma-postgres-odb-staging.herokuapp.com/odb',
-});
+  const odbLink = new HttpLink({ uri: env.odbURI });
 
-const wsLink = new WebSocketLink(
-  new SubscriptionClient(import.meta.env.VITE_NG_WS ?? 'ws://navigate.lucuma.xyz:9070/navigate/ws'),
-);
+  const wsLink = new WebSocketLink(new SubscriptionClient(env.navigateServerWsURI));
 
-export const client = new ApolloClient({
-  name: 'navigate-ui',
-  link: ApolloLink.split(
-    (operation) => operation.getContext().clientName === 'odb',
-    odbLink,
-    ApolloLink.split(
-      (operation) => operation.getContext().clientName === 'navigateConfigs',
-      navigateConfigs,
+  return new ApolloClient({
+    name: 'navigate-ui',
+    link: ApolloLink.split(
+      (operation) => operation.getContext().clientName === 'odb',
+      odbLink,
       ApolloLink.split(
-        ({ query }) => {
-          const definition = getMainDefinition(query);
-          return (
-            definition.kind === Kind.OPERATION_DEFINITION && definition.operation === OperationTypeNode.SUBSCRIPTION
-          );
-        },
-        wsLink,
-        navigateCommandServer,
+        (operation) => operation.getContext().clientName === 'navigateConfigs',
+        navigateConfigs,
+        ApolloLink.split(
+          ({ query }) => {
+            const definition = getMainDefinition(query);
+            return (
+              definition.kind === Kind.OPERATION_DEFINITION && definition.operation === OperationTypeNode.SUBSCRIPTION
+            );
+          },
+          wsLink,
+          navigateCommandServer,
+        ),
       ),
     ),
-  ),
-  cache: new InMemoryCache({
-    dataIdFromObject(responseObject) {
-      // Configure primary-key fields for cache normalization to use 'pk' field
-      if ('pk' in responseObject && (typeof responseObject.pk === 'string' || typeof responseObject.pk === 'number')) {
-        return `${responseObject.__typename}:pk:${responseObject.pk}`;
-      } else {
-        return defaultDataIdFromObject(responseObject);
-      }
-    },
-    // Configure primary-key fields for cache normalization
-    typePolicies: {
-      GuideAlarm: {
-        keyFields: ['wfs'],
+    cache: new InMemoryCache({
+      dataIdFromObject(responseObject) {
+        // Configure primary-key fields for cache normalization to use 'pk' field
+        if (
+          'pk' in responseObject &&
+          (typeof responseObject.pk === 'string' || typeof responseObject.pk === 'number')
+        ) {
+          return `${responseObject.__typename}:pk:${responseObject.pk}`;
+        } else {
+          return defaultDataIdFromObject(responseObject);
+        }
       },
-    },
-  }),
-});
+      // Configure primary-key fields for cache normalization
+      typePolicies: {
+        GuideAlarm: {
+          keyFields: ['wfs'],
+        },
+      },
+    }),
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client';
+import { getEnvironment } from './Helpers/environment';
 
 // Styles
 import './styles/main.scss';
@@ -10,8 +11,10 @@ import { StrictMode } from 'react';
 
 const root = createRoot(document.getElementById('root')!);
 
+const environment = getEnvironment();
+
 root.render(
   <StrictMode>
-    <App />
+    <App environment={environment} />
   </StrictMode>,
 );


### PR DESCRIPTION
Instead of environment variables that are hardcoded into the build output, this will load URI's based on the hostname of the current page. This will allow us to have different URI's for different environments without having to rebuild the application.

A next step would be to publish the dist files somewhere that navigate-server can access them (like on Sonatype). So a build step for this repo is not needed for deploying navigate.
