### PR TITLE
Changed target depending on the swap state

### DIFF
--- a/src/components/Panels/Telescope/Targets/GuiderTargets.tsx
+++ b/src/components/Panels/Telescope/Targets/GuiderTargets.tsx
@@ -78,8 +78,8 @@ export function GuiderTargets() {
       <TargetSwapButton
         selectedTarget={selectedTarget}
         oiSelected={oiSelected}
-        p1Selected={p1Selected}
-        p2Selected={p2Selected}
+        // p1Selected={p1Selected}
+        // p2Selected={p2Selected}
       />
     </div>
   );

--- a/src/components/Panels/Telescope/Targets/GuiderTargets.tsx
+++ b/src/components/Panels/Telescope/Targets/GuiderTargets.tsx
@@ -27,10 +27,12 @@ export function GuiderTargets() {
   const configuration = useConfiguration().data?.configuration;
 
   const selectedTarget: Target | undefined = allTargets.find((t) => t.pk === configuration?.selectedTarget);
+  const oiSelected: Target | undefined = oiTargets.find((t) => t.pk === configuration?.selectedOiTarget);
+  const p1Selected: Target | undefined = p1Targets.find((t) => t.pk === configuration?.selectedP1Target);
+  const p2Selected: Target | undefined = p2Targets.find((t) => t.pk === configuration?.selectedP2Target);
 
   const displayProbes: React.ReactNode[] = [];
   if (oiTargets.length) {
-    const oiSelected = oiTargets.find((t) => t.pk === configuration?.selectedOiTarget);
     displayProbes.push(
       <div key={'OIWFS'} className="guide-probe">
         <Title title={oiSelected ? `OIWFS: ${oiSelected.name}` : 'OIWFS'} />
@@ -41,7 +43,6 @@ export function GuiderTargets() {
   }
 
   if (p1Targets.length) {
-    const p1Selected = p1Targets.find((t) => t.pk === configuration?.selectedP1Target);
     displayProbes.push(
       <div key={'PWFS1'} className="guide-probe">
         <Title title={p1Selected ? `PWFS1: ${p1Selected.name}` : 'PWFS1'} />
@@ -52,7 +53,6 @@ export function GuiderTargets() {
   }
 
   if (p2Targets.length) {
-    const p2Selected = p2Targets.find((t) => t.pk === configuration?.selectedP2Target);
     displayProbes.push(
       <div key={'PWFS2'} className="guide-probe">
         <Title title={p2Selected ? `PWFS2: ${p2Selected.name}` : 'PWFS2'} />
@@ -75,7 +75,12 @@ export function GuiderTargets() {
     <div className="guiders">
       <Title title="Guiders" />
       <div className="body">{displayProbes}</div>
-      <TargetSwapButton selectedTarget={selectedTarget} />
+      <TargetSwapButton
+        selectedTarget={selectedTarget}
+        oiSelected={oiSelected}
+        p1Selected={p1Selected}
+        p2Selected={p2Selected}
+      />
     </div>
   );
 }

--- a/src/components/Panels/Telescope/Targets/TargetSwapButton.test.tsx
+++ b/src/components/Panels/Telescope/Targets/TargetSwapButton.test.tsx
@@ -17,12 +17,7 @@ describe(TargetSwapButton.name, () => {
   describe('onSwappedTarget is false', () => {
     beforeEach(async () => {
       sut = renderWithContext(
-        <TargetSwapButton
-          selectedTarget={selectedTarget as Target}
-          oiSelected={oiSelected as Target}
-          p1Selected={p1Selected as Target}
-          p2Selected={p2Selected as Target}
-        />,
+        <TargetSwapButton selectedTarget={selectedTarget as Target} oiSelected={oiSelected as Target} />,
         {
           mocks: [
             getRotatorMock,
@@ -52,12 +47,7 @@ describe(TargetSwapButton.name, () => {
   describe('onSwappedTarget is true', () => {
     beforeEach(async () => {
       sut = renderWithContext(
-        <TargetSwapButton
-          selectedTarget={selectedTarget as Target}
-          oiSelected={oiSelected as Target}
-          p1Selected={p1Selected as Target}
-          p2Selected={p2Selected as Target}
-        />,
+        <TargetSwapButton selectedTarget={selectedTarget as Target} oiSelected={oiSelected as Target} />,
         {
           mocks: [
             getRotatorMock,
@@ -117,44 +107,6 @@ const oiSelected = {
   el: null,
   epoch: 'J2000.000',
   type: 'OIWFS',
-  createdAt: '2024-09-25T11:57:29.410Z',
-};
-
-const p1Selected = {
-  pk: 11,
-  id: 't-000',
-  name: 'OI Target',
-  ra: {
-    degrees: 56.69542085833334,
-    hms: '03:46:46.901006',
-  },
-  dec: {
-    degrees: 80.07267194527778,
-    dms: '+80:04:21.618990',
-  },
-  az: null,
-  el: null,
-  epoch: 'J2000.000',
-  type: 'P1WFS',
-  createdAt: '2024-09-25T11:57:29.410Z',
-};
-
-const p2Selected = {
-  pk: 12,
-  id: 't-000',
-  name: 'OI Target',
-  ra: {
-    degrees: 56.69542085833334,
-    hms: '03:46:46.901006',
-  },
-  dec: {
-    degrees: 80.07267194527778,
-    dms: '+80:04:21.618990',
-  },
-  az: null,
-  el: null,
-  epoch: 'J2000.000',
-  type: 'P2WFS',
   createdAt: '2024-09-25T11:57:29.410Z',
 };
 

--- a/src/components/Panels/Telescope/Targets/TargetSwapButton.test.tsx
+++ b/src/components/Panels/Telescope/Targets/TargetSwapButton.test.tsx
@@ -16,9 +16,23 @@ describe(TargetSwapButton.name, () => {
 
   describe('onSwappedTarget is false', () => {
     beforeEach(async () => {
-      sut = renderWithContext(<TargetSwapButton selectedTarget={selectedTarget as Target} />, {
-        mocks: [getRotatorMock, getInstrumentMock, getConfigurationMock, swapTargetMock, ...navigateStatesMock(false)],
-      });
+      sut = renderWithContext(
+        <TargetSwapButton
+          selectedTarget={selectedTarget as Target}
+          oiSelected={oiSelected as Target}
+          p1Selected={p1Selected as Target}
+          p2Selected={p2Selected as Target}
+        />,
+        {
+          mocks: [
+            getRotatorMock,
+            getInstrumentMock,
+            getConfigurationMock,
+            swapTargetMock,
+            ...navigateStatesMock(false),
+          ],
+        },
+      );
       // wait for state to load
       await expect.element(sut.getByRole('button')).toBeVisible();
     });
@@ -37,15 +51,23 @@ describe(TargetSwapButton.name, () => {
 
   describe('onSwappedTarget is true', () => {
     beforeEach(async () => {
-      sut = renderWithContext(<TargetSwapButton selectedTarget={selectedTarget as Target} />, {
-        mocks: [
-          getRotatorMock,
-          getInstrumentMock,
-          getConfigurationMock,
-          restoreTargetMock,
-          ...navigateStatesMock(true),
-        ],
-      });
+      sut = renderWithContext(
+        <TargetSwapButton
+          selectedTarget={selectedTarget as Target}
+          oiSelected={oiSelected as Target}
+          p1Selected={p1Selected as Target}
+          p2Selected={p2Selected as Target}
+        />,
+        {
+          mocks: [
+            getRotatorMock,
+            getInstrumentMock,
+            getConfigurationMock,
+            restoreTargetMock,
+            ...navigateStatesMock(true),
+          ],
+        },
+      );
       // wait for state to load
       await expect.element(sut.getByRole('button')).toBeInTheDocument();
     });
@@ -76,6 +98,63 @@ const selectedTarget = {
   el: null,
   epoch: 'J2000.000',
   type: 'SCIENCE',
+  createdAt: '2024-09-25T11:57:29.410Z',
+};
+
+const oiSelected = {
+  pk: 10,
+  id: 't-000',
+  name: 'OI Target',
+  ra: {
+    degrees: 56.69542085833334,
+    hms: '03:46:46.901006',
+  },
+  dec: {
+    degrees: 80.07267194527778,
+    dms: '+80:04:21.618990',
+  },
+  az: null,
+  el: null,
+  epoch: 'J2000.000',
+  type: 'OIWFS',
+  createdAt: '2024-09-25T11:57:29.410Z',
+};
+
+const p1Selected = {
+  pk: 11,
+  id: 't-000',
+  name: 'OI Target',
+  ra: {
+    degrees: 56.69542085833334,
+    hms: '03:46:46.901006',
+  },
+  dec: {
+    degrees: 80.07267194527778,
+    dms: '+80:04:21.618990',
+  },
+  az: null,
+  el: null,
+  epoch: 'J2000.000',
+  type: 'P1WFS',
+  createdAt: '2024-09-25T11:57:29.410Z',
+};
+
+const p2Selected = {
+  pk: 12,
+  id: 't-000',
+  name: 'OI Target',
+  ra: {
+    degrees: 56.69542085833334,
+    hms: '03:46:46.901006',
+  },
+  dec: {
+    degrees: 80.07267194527778,
+    dms: '+80:04:21.618990',
+  },
+  az: null,
+  el: null,
+  epoch: 'J2000.000',
+  type: 'P2WFS',
   createdAt: '2024-09-25T11:57:29.410Z',
 };
 

--- a/src/components/Panels/Telescope/Targets/TargetSwapButton.test.tsx
+++ b/src/components/Panels/Telescope/Targets/TargetSwapButton.test.tsx
@@ -197,12 +197,12 @@ const swapTargetMock: MockedResponse<
         },
         rotator: { ipa: { degrees: 0 }, mode: 'TRACKING' },
         guideTarget: {
-          id: selectedTarget.id,
-          name: selectedTarget.name,
+          id: oiSelected.id,
+          name: oiSelected.name,
           sidereal: {
-            ra: { hms: selectedTarget.ra.hms },
-            dec: { dms: selectedTarget.dec.dms },
-            epoch: selectedTarget.epoch,
+            ra: { hms: oiSelected.ra.hms },
+            dec: { dms: oiSelected.dec.dms },
+            epoch: oiSelected.epoch,
           },
         },
       },

--- a/src/components/Panels/Telescope/Targets/TargetSwapButton.tsx
+++ b/src/components/Panels/Telescope/Targets/TargetSwapButton.tsx
@@ -18,13 +18,13 @@ import { useToast } from '@/Helpers/toast';
 export function TargetSwapButton({
   selectedTarget,
   oiSelected,
-  p1Selected,
-  p2Selected,
+  // p1Selected,
+  // p2Selected,
 }: {
   selectedTarget: Target | undefined;
   oiSelected: Target | undefined;
-  p1Selected: Target | undefined;
-  p2Selected: Target | undefined;
+  // p1Selected: Target | undefined;
+  // p2Selected: Target | undefined;
 }) {
   const canEdit = useCanEdit();
   const toast = useToast();

--- a/src/components/Panels/Telescope/Targets/TargetSwapButton.tsx
+++ b/src/components/Panels/Telescope/Targets/TargetSwapButton.tsx
@@ -15,7 +15,17 @@ import { Button } from 'primereact/button';
 import { useCanEdit } from '@/components/atoms/auth';
 import { useToast } from '@/Helpers/toast';
 
-export function TargetSwapButton({ selectedTarget }: { selectedTarget: Target | undefined }) {
+export function TargetSwapButton({
+  selectedTarget,
+  oiSelected,
+  p1Selected,
+  p2Selected,
+}: {
+  selectedTarget: Target | undefined;
+  oiSelected: Target | undefined;
+  p1Selected: Target | undefined;
+  p2Selected: Target | undefined;
+}) {
   const canEdit = useCanEdit();
   const toast = useToast();
 
@@ -29,40 +39,57 @@ export function TargetSwapButton({ selectedTarget }: { selectedTarget: Target | 
   const { data: instrumentData, loading: instrumentLoading } = useInstrument({
     variables: { name: configuration?.obsInstrument ?? '', issPort: 3, wfs: 'NONE' },
   });
+
+  const { data: acData, loading: acLoading } = useInstrument({
+    variables: { name: `AC_${configuration?.site}` },
+  });
+
+  const acInst = acData?.instrument;
   const instrument = instrumentData?.instrument;
   const { data: rotatorData, loading: rotatorLoading } = useRotator();
   const rotator = rotatorData?.rotator;
 
   const loading =
-    stateLoading || swapLoading || restoreLoading || instrumentLoading || rotatorLoading || configurationLoading;
+    stateLoading ||
+    swapLoading ||
+    restoreLoading ||
+    instrumentLoading ||
+    rotatorLoading ||
+    configurationLoading ||
+    acLoading;
 
   const disabled = !canEdit;
 
   const label = data?.onSwappedTarget ? 'Point to Base' : 'Point to Guide Star';
 
   const onClick = () => {
-    if (selectedTarget?.id && instrument && rotator) {
+    if (selectedTarget?.id && instrument && rotator && oiSelected && acInst) {
       // TODO: other inputs for swap/nonswap
-      const instrumentInput: InstrumentSpecificsInput = {
-        iaa: { degrees: instrument.iaa },
-        focusOffset: { micrometers: instrument.focusOffset },
-        agName: instrument.name,
-        origin: { x: { micrometers: instrument.originX }, y: { micrometers: instrument.originY } },
-      };
       const rotatorInput: RotatorTrackingInput = { ipa: { degrees: rotator.angle }, mode: rotator.tracking };
-      const targetInput: TargetPropertiesInput = {
-        id: selectedTarget.id,
-        name: selectedTarget.name,
-        sidereal: {
-          ra: { hms: selectedTarget?.ra?.hms },
-          dec: { dms: selectedTarget?.dec?.dms },
-          epoch: selectedTarget?.epoch,
-        },
-        // nonsidereal: // <- ???
-        // wavelength: {nanometers: } // <- ???
-      };
 
       if (data?.onSwappedTarget) {
+        // If restoring
+        // Use the instrument associated with the science target
+        const instrumentInput: InstrumentSpecificsInput = {
+          iaa: { degrees: instrument.iaa },
+          focusOffset: { micrometers: instrument.focusOffset },
+          agName: instrument.name,
+          origin: { x: { micrometers: instrument.originX }, y: { micrometers: instrument.originY } },
+        };
+
+        // Use the science target
+        const targetInput: TargetPropertiesInput = {
+          id: selectedTarget.id,
+          name: selectedTarget.name,
+          sidereal: {
+            ra: { hms: selectedTarget?.ra?.hms },
+            dec: { dms: selectedTarget?.dec?.dms },
+            epoch: selectedTarget?.epoch,
+          },
+          // nonsidereal: // <- ???
+          // wavelength: {nanometers: } // <- ???
+        };
+
         void restoreTarget({
           variables: {
             config: {
@@ -74,6 +101,29 @@ export function TargetSwapButton({ selectedTarget }: { selectedTarget: Target | 
           },
         });
       } else {
+        // If swapping
+        // Use the acquisition camera
+        const instrumentInput: InstrumentSpecificsInput = {
+          iaa: { degrees: acInst.iaa },
+          focusOffset: { micrometers: acInst.focusOffset },
+          agName: acInst.name,
+          origin: { x: { micrometers: acInst.originX }, y: { micrometers: acInst.originY } },
+        };
+
+        // Use Guide target if swapping
+        // TODO: Will use OI for now, in the future can be OI, P1 or P2
+        const targetInput: TargetPropertiesInput = {
+          id: oiSelected.id ?? 't-000',
+          name: oiSelected.name,
+          sidereal: {
+            ra: { hms: oiSelected?.ra?.hms },
+            dec: { dms: oiSelected?.dec?.dms },
+            epoch: oiSelected?.epoch,
+          },
+          // nonsidereal: // <- ???
+          // wavelength: {nanometers: } // <- ???
+        };
+
         void swapTarget({
           variables: {
             swapConfig: {

--- a/src/components/Panels/Telescope/Targets/TargetSwapButton.tsx
+++ b/src/components/Panels/Telescope/Targets/TargetSwapButton.tsx
@@ -138,6 +138,10 @@ export function TargetSwapButton({
       let detail;
       if (!selectedTarget) {
         detail = 'No target';
+      } else if (!oiSelected) {
+        detail = 'No guide star';
+      } else if (!acInst) {
+        detail = 'No acquisition camera';
       } else if (!instrument) {
         detail = 'No instrument';
       } else if (!rotator) {


### PR DESCRIPTION
swapTarget command should use the guideTarget instead of the scienceTarget, also the acquisition camera parameters should be used as instrument.

I am assuming we will have records with name `AC_GN` and `AC_GS` in the Instrument table in the local configuration database.