### PR TITLE
Show toast for GraphQL errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import type { ApolloClient, NormalizedCacheObject } from '@apollo/client';
 import { ApolloProvider } from '@apollo/client';
 import { Modals } from '@Contexts/Variables/Modals/Modals';
+import { Provider as AtomProvider } from 'jotai';
 import { useEffect } from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router';
 
+import { store } from './components/atoms/store';
 import { useThemeValue } from './components/atoms/theme';
 import Home from './components/Layout/Home/Home';
 import Layout from './components/Layout/Layout';
@@ -26,12 +28,14 @@ export function App({ client }: { client: ApolloClient<NormalizedCacheObject> })
   }, [theme]);
 
   return (
-    <ApolloProvider client={client}>
-      <ToastProvider>
-        <Modals />
-        <RouterProvider router={router} />
-        <VersionManager />
-      </ToastProvider>
-    </ApolloProvider>
+    <AtomProvider store={store}>
+      <ApolloProvider client={client}>
+        <ToastProvider>
+          <Modals />
+          <RouterProvider router={router} />
+          <VersionManager />
+        </ToastProvider>
+      </ApolloProvider>
+    </AtomProvider>
   );
 }

--- a/src/Helpers/toast.tsx
+++ b/src/Helpers/toast.tsx
@@ -2,7 +2,7 @@ import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { Toast } from 'primereact/toast';
 import { useEffect, useRef } from 'react';
 
-const toastAtom = atom<Toast | null>(null);
+export const toastAtom = atom<Toast | null>(null);
 
 export function useToast() {
   return useAtomValue(toastAtom);

--- a/src/apollo.d.ts
+++ b/src/apollo.d.ts
@@ -1,0 +1,24 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { DefaultContext } from '@apollo/client';
+
+// Extend the DefaultContext interface to include extra properties
+declare module '@apollo/client' {
+  interface DefaultContext {
+    error?: {
+      /**
+       * Toast title to display when an error occurs
+       *
+       * @default 'GraphQL error'
+       */
+      summary: string;
+      /**
+       * Toast message to display when an error occurs
+       *
+       * @default the error message from the error object
+       */
+      detail?: string;
+    };
+
+    clientName?: 'odb' | 'navigateConfigs';
+  }
+}

--- a/src/components/Contexts/Variables/Modals/OdbImport/OdbImport.tsx
+++ b/src/components/Contexts/Variables/Modals/OdbImport/OdbImport.tsx
@@ -90,14 +90,9 @@ export function OdbImport() {
 
         // Observation selected
         // First try to get a central wavelength associated to the observation
-        const obsWithWavelength = await getCentralWavelength({ variables: { obsId: selectedObservation.id } });
-        if (obsWithWavelength.error?.message) {
-          toast?.show({
-            severity: 'warn',
-            summary: `No central wavelength for ${selectedObservation.id}`,
-            detail: obsWithWavelength.error.message,
-          });
-        }
+        const obsWithWavelength = await getCentralWavelength({
+          variables: { obsId: selectedObservation.id },
+        });
 
         const wavelength = extractCentralWavelength(configuration?.site, obsWithWavelength.data);
 
@@ -129,14 +124,10 @@ export function OdbImport() {
         // If there is a rotator, retrieve guide targets and create them
         if (rotator) {
           // Get the guide environment separately to avoid large query times for _all_ observations
-          const guideEnv = await getGuideEnvironment({ variables: { obsId: selectedObservation.id } });
-          if (guideEnv.error?.message) {
-            toast?.show({
-              severity: 'warn',
-              summary: `No guide environment for ${selectedObservation.id}`,
-              detail: guideEnv.error.message,
-            });
-          }
+          const guideEnv = await getGuideEnvironment({
+            variables: { obsId: selectedObservation.id },
+          });
+
           const { oiwfs, pwfs1, pwfs2 } = extractGuideTargets(guideEnv.data);
 
           const [oi, p1, p2] = await Promise.all([
@@ -196,7 +187,7 @@ export function OdbImport() {
         detail: 'Please select at least one instrument',
       });
     } else {
-      const res = await getReadyObservations({
+      await getReadyObservations({
         variables: {
           instruments: instrumentsInput,
           states: ['READY', 'ONGOING'],
@@ -204,13 +195,6 @@ export function OdbImport() {
         },
         fetchPolicy: 'no-cache',
       });
-      if (res.error?.message) {
-        toast?.show({
-          severity: 'error',
-          summary: 'Error querying observations',
-          detail: res.error.message,
-        });
-      }
     }
   }, [getReadyObservations, instrumentsInput, semesterInput, semester, toast]);
 

--- a/src/components/atoms/store.ts
+++ b/src/components/atoms/store.ts
@@ -1,0 +1,3 @@
+import { createStore } from 'jotai';
+
+export const store = createStore();

--- a/src/gql/ApolloConfigs.ts
+++ b/src/gql/ApolloConfigs.ts
@@ -7,7 +7,9 @@ import { getMainDefinition } from '@apollo/client/utilities';
 import { Kind, OperationTypeNode } from 'graphql/language';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
 
+import { store } from '@/components/atoms/store';
 import type { Environment } from '@/Helpers/environment';
+import { toastAtom } from '@/Helpers/toast';
 
 /**
  * Converts a relative URI to an absolute URI based on the current window origin.
@@ -19,15 +21,24 @@ const withAbsoluteUri = (uri: string, isWs = false) => {
   return isWs ? newUri.replace(/^http/, 'ws') : newUri;
 };
 
-// Log errors to the console
-const errorLink = onError(({ graphQLErrors, networkError }) => {
-  if (graphQLErrors)
-    graphQLErrors.forEach(({ message, locations, path }) =>
-      console.warn(
-        `[GraphQL error]: ${message.trim()}
-        Path: ${(path ?? [])?.join(', ')} ${(locations ?? [])?.map((l) => `[${l.line}:${l.column}]`).join(', ')}`,
-      ),
-    );
+// Log errors to the console and show a toast
+const errorLink = onError(({ operation, graphQLErrors, networkError }) => {
+  const ctx = operation.getContext();
+  // Extract either the context error message, or the first GraphQL error message
+  const errorMessage = ctx.error?.detail ?? graphQLErrors?.[0]?.message?.trim();
+  if (errorMessage) {
+    store.get(toastAtom)?.show({
+      severity: 'error',
+      contentClassName: 'graphql-error-toast',
+      summary: ctx.error?.summary ?? 'GraphQL error',
+      detail: errorMessage,
+      life: 10000,
+    });
+  }
+
+  graphQLErrors?.forEach(({ message, locations, path }) => {
+    console.warn(`[GraphQL error]`, message.trim(), { path, locations, ctx });
+  });
 
   if (networkError) console.error(`[Network error]`, networkError);
 });

--- a/src/gql/server/Buttons.tsx
+++ b/src/gql/server/Buttons.tsx
@@ -10,11 +10,9 @@ import type { VariablesOf } from '@graphql-typed-document-node/core';
 import { clsx } from 'clsx';
 import type { ButtonProps } from 'primereact/button';
 import { Button } from 'primereact/button';
-import { useEffect } from 'react';
 
 import { BTN_CLASSES } from '@/Helpers/constants';
 import type { SetStale } from '@/Helpers/hooks';
-import { useToast } from '@/Helpers/toast';
 import type { SlewFlagsType } from '@/types';
 
 import { MOUNT_FOLLOW_MUTATION, OIWFS_FOLLOW_MUTATION, ROTATOR_FOLLOW_MUTATION, SCS_FOLLOW_MUTATION } from './follow';
@@ -33,23 +31,10 @@ function MutationButton<T extends DocumentNode>({
   variables: VariablesOf<T> extends OperationVariables ? VariablesOf<T> : never;
   setStale?: SetStale;
 } & ButtonProps) {
-  const TOAST_LIFE = 5000;
-  const toast = useToast();
-  const [mutationFunction, { loading, error }] = useMutation<T>(mutation, {
+  const [mutationFunction, { loading }] = useMutation<T>(mutation, {
     variables: variables,
     onCompleted: () => setStale?.(true),
   });
-
-  useEffect(() => {
-    if (error) {
-      toast?.show({
-        severity: 'error',
-        summary: error.name,
-        detail: error.message,
-        life: TOAST_LIFE,
-      });
-    }
-  }, [error, toast]);
 
   return <Button {...props} onClick={() => void mutationFunction({ variables })} loading={props.loading || loading} />;
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -144,6 +144,12 @@ button.p-component.p-button {
   }
 }
 
+.graphql-error-toast .p-toast-detail {
+  font-size: 0.8rem;
+  // Whitespaces in the error message are preserved
+  white-space: pre-wrap;
+}
+
 .dark .p-checkbox .p-checkbox-box,
 .light .p-checkbox .p-checkbox-box {
   border-width: 1px;


### PR DESCRIPTION
By default, any graphql errors will be shown in a toast. This can be overridden by setting the `error` context object in the operation:

```typescript
useQuery(GET_DATA, {
  context: {
    error: {
      // Defaults to 'GraphQL error'
      summary: 'Custom error title',
      // Defaults to the error message from the error object
      detail: 'Custom error message',
    },
  },
});
```
