### PR TITLE
Change focusOffset input from micrometers to millimeters

### DIFF
--- a/packages/ui/src/components/Panels/Telescope/Targets/TargetSwapButton.test.tsx
+++ b/packages/ui/src/components/Panels/Telescope/Targets/TargetSwapButton.test.tsx
@@ -57,7 +57,7 @@ describe(TargetSwapButton.name, () => {
         swapConfig: {
           acParams: {
             iaa: { degrees: 359.856 },
-            focusOffset: { micrometers: 0 },
+            focusOffset: { millimeters: 0 },
             agName: 'GMOS_NORTH',
             origin: { x: { arcseconds: 0 }, y: { arcseconds: 0 } },
           },
@@ -128,7 +128,7 @@ describe(TargetSwapButton.name, () => {
           instParams: {
             agName: 'GMOS_NORTH',
             focusOffset: {
-              micrometers: 0,
+              millimeters: 0,
             },
             iaa: {
               degrees: 359.856,

--- a/packages/ui/src/components/Panels/Telescope/Targets/inputs.ts
+++ b/packages/ui/src/components/Panels/Telescope/Targets/inputs.ts
@@ -36,7 +36,7 @@ export function createRotatorTrackingInput(rotator: Rotator): RotatorTrackingInp
 export function createInstrumentSpecificsInput(instrument: InstrumentConfig): InstrumentSpecificsInput {
   return {
     iaa: { degrees: instrument.iaa },
-    focusOffset: { micrometers: instrument.focusOffset },
+    focusOffset: { millimeters: instrument.focusOffset },
     agName: instrument.name,
     origin: { x: { arcseconds: instrument.originX }, y: { arcseconds: instrument.originY } },
   };

--- a/packages/ui/src/gql/server/Buttons.test.tsx
+++ b/packages/ui/src/gql/server/Buttons.test.tsx
@@ -58,7 +58,7 @@ describe(Slew.name, () => {
           "instParams": {
             "agName": "ACQ_CAM",
             "focusOffset": {
-              "micrometers": 0,
+              "millimeters": 0,
             },
             "iaa": {
               "degrees": 0,


### PR DESCRIPTION
UI sent focusOffset: { micrometers: -0.086 }. The displayed offset is -0.086. The correct value is in millimeters, not micrometer.