### PR TITLE
Only query fields in DB that are requested in GraphQL query

### DIFF
--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -33,6 +33,7 @@
     "@prisma/adapter-pg": "7.8.0",
     "@prisma/client": "7.8.0",
     "graphql": "16.14.1",
+    "graphql-parse-resolve-info": "4.14.1",
     "graphql-scalars": "1.25.0",
     "graphql-yoga": "5.21.0",
     "prisma": "7.8.0"

--- a/packages/configs/src/graphql/resolvers/Mutation/createCalParams.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/createCalParams.ts
@@ -1,7 +1,9 @@
 import type { MutationResolvers } from '../../gen/types.generated.ts';
+import { resolveSelectFields } from '../query-fields.ts';
 
-export const createCalParams: NonNullable<MutationResolvers['createCalParams']> = (_parent, args, { prisma }) => {
+export const createCalParams: NonNullable<MutationResolvers['createCalParams']> = (_parent, args, { prisma }, info) => {
   return prisma.calParams.create({
     data: args.input,
+    ...resolveSelectFields<'CalParams'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/createConfiguration.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/createConfiguration.ts
@@ -1,9 +1,14 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { Configuration, MutationResolvers } from './../../gen/types.generated.ts';
 
 export const createConfiguration: NonNullable<MutationResolvers['createConfiguration']> = (
   _parent,
   args,
   { prisma },
+  info,
 ) => {
-  return prisma.configuration.create({ data: args }) as Promise<Configuration>;
+  return prisma.configuration.create({
+    data: args,
+    ...resolveSelectFields<'Configuration'>(info),
+  }) as Promise<Configuration>;
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/createEngineeringTarget.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/createEngineeringTarget.ts
@@ -1,9 +1,11 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { EngineeringTarget, MutationResolvers } from './../../gen/types.generated.ts';
 
 export const createEngineeringTarget: NonNullable<MutationResolvers['createEngineeringTarget']> = (
   _parent,
   args,
   { prisma },
+  info,
 ) => {
   if (args.type === 'FIXED') {
     // Some logics depending on the input
@@ -15,5 +17,6 @@ export const createEngineeringTarget: NonNullable<MutationResolvers['createEngin
   }
   return prisma.engineeringTarget.create({
     data: args as typeof args & { coord1: number; coord2: number },
+    ...resolveSelectFields<'EngineeringTarget'>(info),
   }) as Promise<EngineeringTarget>;
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/createInstrument.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/createInstrument.ts
@@ -1,5 +1,14 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { InstrumentConfig, MutationResolvers } from './../../gen/types.generated.ts';
 
-export const createInstrument: NonNullable<MutationResolvers['createInstrument']> = (_parent, args, { prisma }) => {
-  return prisma.instrument.create({ data: { extraParams: {}, ...args } }) as Promise<InstrumentConfig>;
+export const createInstrument: NonNullable<MutationResolvers['createInstrument']> = (
+  _parent,
+  args,
+  { prisma },
+  info,
+) => {
+  return prisma.instrument.create({
+    data: { extraParams: {}, ...args },
+    ...resolveSelectFields<'Instrument'>(info),
+  }) as Promise<InstrumentConfig>;
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/deleteCalParams.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/deleteCalParams.ts
@@ -1,7 +1,14 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.js';
 
-export const deleteCalParams: NonNullable<MutationResolvers['deleteCalParams']> = async (_parent, args, { prisma }) => {
+export const deleteCalParams: NonNullable<MutationResolvers['deleteCalParams']> = async (
+  _parent,
+  args,
+  { prisma },
+  info,
+) => {
   await prisma.calParams.delete({
     where: { pk: args.pk },
+    ...resolveSelectFields<'CalParams'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/deleteInstrument.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/deleteInstrument.ts
@@ -1,9 +1,11 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.ts';
 
 export const deleteInstrument: NonNullable<MutationResolvers['deleteInstrument']> = async (
   _parent,
   args,
   { prisma },
+  info,
 ) => {
-  await prisma.instrument.delete({ where: { pk: args.pk } });
+  await prisma.instrument.delete({ where: { pk: args.pk }, ...resolveSelectFields<'Instrument'>(info) });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/removeAndCreateBaseTargets.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/removeAndCreateBaseTargets.ts
@@ -1,10 +1,12 @@
 import type { Target } from '../../../prisma/gen/client.ts';
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.ts';
 
 export const removeAndCreateBaseTargets: NonNullable<MutationResolvers['removeAndCreateBaseTargets']> = async (
   _parent,
   args,
   { prisma },
+  info,
 ) =>
   prisma.$transaction(async (prisma) => {
     await prisma.target.deleteMany({
@@ -21,10 +23,7 @@ export const removeAndCreateBaseTargets: NonNullable<MutationResolvers['removeAn
           sidereal: t.sidereal ? { create: { ...t.sidereal, type: t.type } } : undefined,
           nonsidereal: t.nonsidereal ? { create: t.nonsidereal } : undefined,
         },
-        include: {
-          sidereal: true,
-          nonsidereal: true,
-        },
+        ...resolveSelectFields<'Target'>(info),
       });
       newTargets.push(result);
     }

--- a/packages/configs/src/graphql/resolvers/Mutation/revertCalParams.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/revertCalParams.ts
@@ -1,8 +1,15 @@
 import { GraphQLError } from 'graphql';
 
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.js';
 
-export const revertCalParams: NonNullable<MutationResolvers['revertCalParams']> = async (_parent, args, { prisma }) => {
+export const revertCalParams: NonNullable<MutationResolvers['revertCalParams']> = async (
+  _parent,
+  args,
+  { prisma },
+  info,
+) => {
+  const selectFields = resolveSelectFields<'CalParams'>(info);
   const oldCalParams = await prisma.calParams.findFirst({
     where: { pk: args.pk },
     omit: {
@@ -10,6 +17,7 @@ export const revertCalParams: NonNullable<MutationResolvers['revertCalParams']> 
       comment: true,
       createdAt: true,
     },
+    ...selectFields,
   });
 
   if (!oldCalParams) {
@@ -22,5 +30,6 @@ export const revertCalParams: NonNullable<MutationResolvers['revertCalParams']> 
       createdAt: undefined, // Let the database set the createdAt to now
       comment: args.comment,
     },
+    ...selectFields,
   });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/setTemporaryInstrument.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/setTemporaryInstrument.ts
@@ -1,9 +1,11 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { InstrumentConfig, MutationResolvers } from './../../gen/types.generated.ts';
 
 export const setTemporaryInstrument: NonNullable<MutationResolvers['setTemporaryInstrument']> = async (
   _parent,
   args,
   { prisma },
+  info,
 ) => {
   const tempInstrument = await prisma.instrument.findFirst({
     where: { name: args.name, issPort: args.issPort, wfs: args.wfs, isTemporary: true },
@@ -14,10 +16,12 @@ export const setTemporaryInstrument: NonNullable<MutationResolvers['setTemporary
     return prisma.instrument.update({
       where: { pk: tempInstrument.pk },
       data: args,
+      ...resolveSelectFields<'Instrument'>(info),
     }) as Promise<InstrumentConfig>;
   } else {
     return prisma.instrument.create({
       data: { extraParams: {}, ...args, isTemporary: true },
+      ...resolveSelectFields<'Instrument'>(info),
     }) as Promise<InstrumentConfig>;
   }
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateAltairGuideLoop.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateAltairGuideLoop.ts
@@ -1,12 +1,15 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.ts';
 
 export const updateAltairGuideLoop: NonNullable<MutationResolvers['updateAltairGuideLoop']> = (
   _parent,
   args,
   { prisma },
+  info,
 ) => {
   return prisma.altairGuideLoop.update({
     where: { pk: args.pk },
     data: args,
+    ...resolveSelectFields<'AltairGuideLoop'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateAltairInstrument.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateAltairInstrument.ts
@@ -1,12 +1,15 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.ts';
 
 export const updateAltairInstrument: NonNullable<MutationResolvers['updateAltairInstrument']> = (
   _parent,
   args,
   { prisma },
+  info,
 ) => {
   return prisma.altairInstrument.update({
     where: { pk: args.pk },
     data: args,
+    ...resolveSelectFields<'AltairInstrument'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateConfiguration.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateConfiguration.ts
@@ -1,12 +1,15 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { Configuration, MutationResolvers } from './../../gen/types.generated.ts';
 
 export const updateConfiguration: NonNullable<MutationResolvers['updateConfiguration']> = (
   _parent,
   args,
   { prisma },
+  info,
 ) => {
   return prisma.configuration.update({
     where: { pk: args.pk },
     data: args,
+    ...resolveSelectFields<'Configuration'>(info),
   }) as Promise<Configuration>;
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateEngineeringTarget.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateEngineeringTarget.ts
@@ -1,12 +1,15 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { EngineeringTarget, MutationResolvers } from './../../gen/types.generated.ts';
 
 export const updateEngineeringTarget: NonNullable<MutationResolvers['updateEngineeringTarget']> = (
   _parent,
   args,
   { prisma },
+  info,
 ) => {
   return prisma.engineeringTarget.update({
     where: { pk: args.pk },
     data: args,
+    ...resolveSelectFields<'EngineeringTarget'>(info),
   }) as Promise<EngineeringTarget>;
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateGemsGuideLoop.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateGemsGuideLoop.ts
@@ -1,12 +1,15 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.ts';
 
 export const updateGemsGuideLoop: NonNullable<MutationResolvers['updateGemsGuideLoop']> = (
   _parent,
   args,
   { prisma },
+  info,
 ) => {
   return prisma.gemsGuideLoop.update({
     where: { pk: args.pk },
     data: args,
+    ...resolveSelectFields<'GemsGuideLoop'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateGemsInstrument.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateGemsInstrument.ts
@@ -1,12 +1,15 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.ts';
 
 export const updateGemsInstrument: NonNullable<MutationResolvers['updateGemsInstrument']> = (
   _parent,
   args,
   { prisma },
+  info,
 ) => {
   return prisma.gemsInstrument.update({
     where: { pk: args.pk },
     data: args,
+    ...resolveSelectFields<'GemsInstrument'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateGuideAlarm.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateGuideAlarm.ts
@@ -1,8 +1,15 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.ts';
 
-export const updateGuideAlarm: NonNullable<MutationResolvers['updateGuideAlarm']> = (_parent, args, { prisma }) => {
+export const updateGuideAlarm: NonNullable<MutationResolvers['updateGuideAlarm']> = (
+  _parent,
+  args,
+  { prisma },
+  info,
+) => {
   return prisma.guideAlarm.update({
     where: { wfs: args.wfs },
     data: args,
+    ...resolveSelectFields<'GuideAlarm'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateGuideLoop.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateGuideLoop.ts
@@ -1,8 +1,10 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.ts';
 
-export const updateGuideLoop: NonNullable<MutationResolvers['updateGuideLoop']> = (_parent, args, { prisma }) => {
+export const updateGuideLoop: NonNullable<MutationResolvers['updateGuideLoop']> = (_parent, args, { prisma }, info) => {
   return prisma.guideLoop.update({
     where: { pk: args.pk },
     data: args,
+    ...resolveSelectFields<'GuideLoop'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateInstrument.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateInstrument.ts
@@ -1,8 +1,15 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { InstrumentConfig, MutationResolvers } from './../../gen/types.generated.ts';
 
-export const updateInstrument: NonNullable<MutationResolvers['updateInstrument']> = (_parent, args, { prisma }) => {
+export const updateInstrument: NonNullable<MutationResolvers['updateInstrument']> = (
+  _parent,
+  args,
+  { prisma },
+  info,
+) => {
   return prisma.instrument.update({
     where: { pk: args.pk },
     data: args,
+    ...resolveSelectFields<'Instrument'>(info),
   }) as Promise<InstrumentConfig>;
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateMechanism.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateMechanism.ts
@@ -1,8 +1,10 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.ts';
 
-export const updateMechanism: NonNullable<MutationResolvers['updateMechanism']> = (_parent, args, { prisma }) => {
+export const updateMechanism: NonNullable<MutationResolvers['updateMechanism']> = (_parent, args, { prisma }, info) => {
   return prisma.mechanism.update({
     where: { pk: args.pk },
     data: args,
+    ...resolveSelectFields<'Mechanism'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateRotator.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateRotator.ts
@@ -1,8 +1,10 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.ts';
 
-export const updateRotator: NonNullable<MutationResolvers['updateRotator']> = (_parent, args, { prisma }) => {
+export const updateRotator: NonNullable<MutationResolvers['updateRotator']> = (_parent, args, { prisma }, info) => {
   return prisma.rotator.update({
     where: { pk: args.pk },
     data: args,
+    ...resolveSelectFields<'Rotator'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateSlewFlags.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateSlewFlags.ts
@@ -1,8 +1,10 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.ts';
 
-export const updateSlewFlags: NonNullable<MutationResolvers['updateSlewFlags']> = (_parent, args, { prisma }) => {
+export const updateSlewFlags: NonNullable<MutationResolvers['updateSlewFlags']> = (_parent, args, { prisma }, info) => {
   return prisma.slewFlags.update({
     where: { pk: args.pk },
     data: args,
+    ...resolveSelectFields<'SlewFlags'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/Mutation/updateTarget.ts
+++ b/packages/configs/src/graphql/resolvers/Mutation/updateTarget.ts
@@ -1,6 +1,7 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { MutationResolvers } from './../../gen/types.generated.ts';
 
-export const updateTarget: NonNullable<MutationResolvers['updateTarget']> = (_parent, args, { prisma }) => {
+export const updateTarget: NonNullable<MutationResolvers['updateTarget']> = (_parent, args, { prisma }, info) => {
   return prisma.target.update({
     where: { pk: args.pk },
     data: {
@@ -10,9 +11,6 @@ export const updateTarget: NonNullable<MutationResolvers['updateTarget']> = (_pa
         : undefined,
       nonsidereal: args.nonsidereal ? { update: { where: { targetPk: args.pk }, data: args.nonsidereal } } : undefined,
     },
-    include: {
-      sidereal: true,
-      nonsidereal: true,
-    },
+    ...resolveSelectFields<'Target'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/Query/altairGuideLoop.ts
+++ b/packages/configs/src/graphql/resolvers/Query/altairGuideLoop.ts
@@ -1,5 +1,6 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { QueryResolvers } from './../../gen/types.generated.ts';
 
-export const altairGuideLoop: NonNullable<QueryResolvers['altairGuideLoop']> = (_parent, args, { prisma }) => {
-  return prisma.altairGuideLoop.findFirst({ where: args });
+export const altairGuideLoop: NonNullable<QueryResolvers['altairGuideLoop']> = (_parent, args, { prisma }, info) => {
+  return prisma.altairGuideLoop.findFirst({ where: args, ...resolveSelectFields<'AltairGuideLoop'>(info) });
 };

--- a/packages/configs/src/graphql/resolvers/Query/altairInstrument.ts
+++ b/packages/configs/src/graphql/resolvers/Query/altairInstrument.ts
@@ -1,5 +1,6 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { QueryResolvers } from './../../gen/types.generated.ts';
 
-export const altairInstrument: NonNullable<QueryResolvers['altairInstrument']> = (_parent, args, { prisma }) => {
-  return prisma.altairInstrument.findFirst({ where: args });
+export const altairInstrument: NonNullable<QueryResolvers['altairInstrument']> = (_parent, args, { prisma }, info) => {
+  return prisma.altairInstrument.findFirst({ where: args, ...resolveSelectFields<'AltairInstrument'>(info) });
 };

--- a/packages/configs/src/graphql/resolvers/Query/calParams.ts
+++ b/packages/configs/src/graphql/resolvers/Query/calParams.ts
@@ -1,12 +1,14 @@
 import { GraphQLError } from 'graphql';
 
 import { INITIAL_CAL_PARAMS } from '../../../prisma/queries/init/calParams.ts';
+import { resolveSelectFields } from '../query-fields.ts';
 import type { QueryResolvers } from './../../gen/types.generated.js';
 
-export const calParams: NonNullable<QueryResolvers['calParams']> = async (_parent, args, { prisma }) => {
+export const calParams: NonNullable<QueryResolvers['calParams']> = async (_parent, args, { prisma }, info) => {
   const calParams = await prisma.calParams.findFirst({
     where: { site: args.site },
     orderBy: { createdAt: 'desc' },
+    ...resolveSelectFields<'CalParams'>(info),
   });
 
   if (calParams) {

--- a/packages/configs/src/graphql/resolvers/Query/calParamsHistory.ts
+++ b/packages/configs/src/graphql/resolvers/Query/calParamsHistory.ts
@@ -1,13 +1,15 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { QueryResolvers } from './../../gen/types.generated.js';
 
-export const calParamsHistory: NonNullable<QueryResolvers['calParamsHistory']> = async (_parent, args, { prisma }) => {
+export const calParamsHistory: NonNullable<QueryResolvers['calParamsHistory']> = async (
+  _parent,
+  args,
+  { prisma },
+  info,
+) => {
   return prisma.calParams.findMany({
     where: args,
-    select: {
-      pk: true,
-      comment: true,
-      createdAt: true,
-    },
+    ...resolveSelectFields<'CalParams'>(info),
     orderBy: { createdAt: 'desc' },
   });
 };

--- a/packages/configs/src/graphql/resolvers/Query/configuration.ts
+++ b/packages/configs/src/graphql/resolvers/Query/configuration.ts
@@ -1,5 +1,9 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { Configuration, QueryResolvers } from './../../gen/types.generated.ts';
 
-export const configuration: NonNullable<QueryResolvers['configuration']> = (_parent, args, { prisma }) => {
-  return prisma.configuration.findFirst({ where: args }) as Promise<Configuration | null>;
+export const configuration: NonNullable<QueryResolvers['configuration']> = (_parent, args, { prisma }, info) => {
+  return prisma.configuration.findFirst({
+    where: args,
+    ...resolveSelectFields<'Configuration'>(info),
+  }) as Promise<Configuration | null>;
 };

--- a/packages/configs/src/graphql/resolvers/Query/engineeringTarget.ts
+++ b/packages/configs/src/graphql/resolvers/Query/engineeringTarget.ts
@@ -1,7 +1,14 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { EngineeringTarget, QueryResolvers } from './../../gen/types.generated.ts';
 
-export const engineeringTarget: NonNullable<QueryResolvers['engineeringTarget']> = (_parent, args, { prisma }) => {
+export const engineeringTarget: NonNullable<QueryResolvers['engineeringTarget']> = (
+  _parent,
+  args,
+  { prisma },
+  info,
+) => {
   return prisma.engineeringTarget.findFirst({
     where: args,
+    ...resolveSelectFields<'EngineeringTarget'>(info),
   }) as Promise<EngineeringTarget | null>;
 };

--- a/packages/configs/src/graphql/resolvers/Query/engineeringTargets.ts
+++ b/packages/configs/src/graphql/resolvers/Query/engineeringTargets.ts
@@ -1,8 +1,15 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { EngineeringTarget, QueryResolvers } from './../../gen/types.generated.ts';
 
-export const engineeringTargets: NonNullable<QueryResolvers['engineeringTargets']> = (_parent, args, { prisma }) => {
+export const engineeringTargets: NonNullable<QueryResolvers['engineeringTargets']> = (
+  _parent,
+  args,
+  { prisma },
+  info,
+) => {
   return prisma.engineeringTarget.findMany({
     where: args,
     orderBy: { createdAt: 'desc' },
+    ...resolveSelectFields<'EngineeringTarget'>(info),
   }) as Promise<EngineeringTarget[]>;
 };

--- a/packages/configs/src/graphql/resolvers/Query/gemsGuideLoop.ts
+++ b/packages/configs/src/graphql/resolvers/Query/gemsGuideLoop.ts
@@ -1,5 +1,6 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { QueryResolvers } from './../../gen/types.generated.ts';
 
-export const gemsGuideLoop: NonNullable<QueryResolvers['gemsGuideLoop']> = (_parent, args, { prisma }) => {
-  return prisma.gemsGuideLoop.findFirst({ where: args });
+export const gemsGuideLoop: NonNullable<QueryResolvers['gemsGuideLoop']> = (_parent, args, { prisma }, info) => {
+  return prisma.gemsGuideLoop.findFirst({ where: args, ...resolveSelectFields<'GemsGuideLoop'>(info) });
 };

--- a/packages/configs/src/graphql/resolvers/Query/gemsInstrument.ts
+++ b/packages/configs/src/graphql/resolvers/Query/gemsInstrument.ts
@@ -1,5 +1,6 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { QueryResolvers } from './../../gen/types.generated.ts';
 
-export const gemsInstrument: NonNullable<QueryResolvers['gemsInstrument']> = (_parent, args, { prisma }) => {
-  return prisma.gemsInstrument.findFirst({ where: args });
+export const gemsInstrument: NonNullable<QueryResolvers['gemsInstrument']> = (_parent, args, { prisma }, info) => {
+  return prisma.gemsInstrument.findFirst({ where: args, ...resolveSelectFields<'GemsInstrument'>(info) });
 };

--- a/packages/configs/src/graphql/resolvers/Query/guideAlarms.ts
+++ b/packages/configs/src/graphql/resolvers/Query/guideAlarms.ts
@@ -1,5 +1,4 @@
-import type { FieldNode } from 'graphql';
-
+import { resolveSelectFields } from '../query-fields.ts';
 import type { GuideAlarm, QueryResolvers, WfsType } from './../../gen/types.generated.ts';
 
 export const guideAlarms: NonNullable<QueryResolvers['guideAlarms']> = async (
@@ -8,12 +7,8 @@ export const guideAlarms: NonNullable<QueryResolvers['guideAlarms']> = async (
   { prisma, log },
   info,
 ) => {
-  // Get the wfs types to query for from the graphql info object
-  const wfsTypesToQuery =
-    ((info.fieldNodes[0]?.selectionSet?.selections as FieldNode[])
-      .map((selection) => selection.name.value)
-      .filter((wfs) => wfs !== '__typename') as WfsType[]) ?? [];
-
+  const resolvedFields = resolveSelectFields<'GuideAlarm'>(info);
+  const wfsTypesToQuery = Object.keys(resolvedFields.select ?? {}) as WfsType[];
   const alarms = await prisma.guideAlarm.findMany({
     where: {
       wfs: {

--- a/packages/configs/src/graphql/resolvers/Query/guideLoop.ts
+++ b/packages/configs/src/graphql/resolvers/Query/guideLoop.ts
@@ -1,5 +1,6 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { QueryResolvers } from './../../gen/types.generated.ts';
 
-export const guideLoop: NonNullable<QueryResolvers['guideLoop']> = (_parent, args, { prisma }) => {
-  return prisma.guideLoop.findFirst({ where: args });
+export const guideLoop: NonNullable<QueryResolvers['guideLoop']> = (_parent, args, { prisma }, info) => {
+  return prisma.guideLoop.findFirst({ where: args, ...resolveSelectFields<'GuideLoop'>(info) });
 };

--- a/packages/configs/src/graphql/resolvers/Query/instrument.ts
+++ b/packages/configs/src/graphql/resolvers/Query/instrument.ts
@@ -1,15 +1,19 @@
 import type { InputJsonValue } from '@prisma/client/runtime/client';
 
 import type { InstrumentWhereInput, JsonFilter } from '../../../prisma/gen/models.ts';
+import { resolveSelectFields } from '../query-fields.ts';
 import type { InstrumentConfig, QueryResolvers } from './../../gen/types.generated.ts';
 
-export const instrument: NonNullable<QueryResolvers['instrument']> = async (_parent, args, { prisma, log }) => {
+export const instrument: NonNullable<QueryResolvers['instrument']> = async (_parent, args, { prisma, log }, info) => {
+  const fieldsToQuery = resolveSelectFields<'Instrument'>(info);
+
   const baseWhereArgs = {
     ...args,
     extraParams: createExtraParamsFilter(args.extraParams),
   } satisfies InstrumentWhereInput;
 
   let instrument = await prisma.instrument.findFirst({
+    ...fieldsToQuery,
     where: baseWhereArgs,
     orderBy: [{ isTemporary: 'desc' }, { createdAt: 'desc' }],
   });
@@ -20,6 +24,7 @@ export const instrument: NonNullable<QueryResolvers['instrument']> = async (_par
   // Try to get the instrument using wfs NONE
   if (args.wfs !== 'NONE') {
     instrument = await prisma.instrument.findFirst({
+      ...fieldsToQuery,
       where: {
         ...baseWhereArgs,
         wfs: 'NONE',
@@ -33,6 +38,7 @@ export const instrument: NonNullable<QueryResolvers['instrument']> = async (_par
   if (!instrument) {
     log.debug(`No instrument found for ${JSON.stringify(args, undefined, 2)}, creating default configuration`);
     instrument = await prisma.instrument.create({
+      ...fieldsToQuery,
       data: {
         name: args.name ?? '',
         issPort: args.issPort ?? 1,
@@ -62,6 +68,7 @@ export const instrument: NonNullable<QueryResolvers['instrument']> = async (_par
         extraParams: {},
         comment: 'Default fallback configuration, using parameters from previous configuration',
       },
+      ...fieldsToQuery,
     });
   }
   return instrument as InstrumentConfig;

--- a/packages/configs/src/graphql/resolvers/Query/instruments.ts
+++ b/packages/configs/src/graphql/resolvers/Query/instruments.ts
@@ -1,9 +1,11 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { InstrumentConfig, QueryResolvers } from './../../gen/types.generated.ts';
 import { createExtraParamsFilter } from './instrument.ts';
 
-export const instruments: NonNullable<QueryResolvers['instruments']> = (_parent, args, { prisma }) => {
+export const instruments: NonNullable<QueryResolvers['instruments']> = (_parent, args, { prisma }, info) => {
   return prisma.instrument.findMany({
     where: { ...args, extraParams: createExtraParamsFilter(args.extraParams) },
+    ...resolveSelectFields<'Instrument'>(info),
     orderBy: [{ isTemporary: 'desc' }, { createdAt: 'desc' }],
   }) as Promise<InstrumentConfig[]>;
 };

--- a/packages/configs/src/graphql/resolvers/Query/mechanism.ts
+++ b/packages/configs/src/graphql/resolvers/Query/mechanism.ts
@@ -1,5 +1,6 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { QueryResolvers } from './../../gen/types.generated.ts';
 
-export const mechanism: NonNullable<QueryResolvers['mechanism']> = (_parent, args, { prisma }) => {
-  return prisma.mechanism.findFirst({ where: args });
+export const mechanism: NonNullable<QueryResolvers['mechanism']> = (_parent, args, { prisma }, info) => {
+  return prisma.mechanism.findFirst({ where: args, ...resolveSelectFields<'Mechanism'>(info) });
 };

--- a/packages/configs/src/graphql/resolvers/Query/rotator.ts
+++ b/packages/configs/src/graphql/resolvers/Query/rotator.ts
@@ -1,5 +1,6 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { QueryResolvers } from './../../gen/types.generated.ts';
 
-export const rotator: NonNullable<QueryResolvers['rotator']> = (_parent, args, { prisma }) => {
-  return prisma.rotator.findFirst({ where: args });
+export const rotator: NonNullable<QueryResolvers['rotator']> = (_parent, args, { prisma }, info) => {
+  return prisma.rotator.findFirst({ where: args, ...resolveSelectFields<'Rotator'>(info) });
 };

--- a/packages/configs/src/graphql/resolvers/Query/slewFlags.ts
+++ b/packages/configs/src/graphql/resolvers/Query/slewFlags.ts
@@ -1,5 +1,6 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { QueryResolvers } from './../../gen/types.generated.ts';
 
-export const slewFlags: NonNullable<QueryResolvers['slewFlags']> = (_parent, args, { prisma }) => {
-  return prisma.slewFlags.findFirst({ where: args });
+export const slewFlags: NonNullable<QueryResolvers['slewFlags']> = (_parent, args, { prisma }, info) => {
+  return prisma.slewFlags.findFirst({ where: args, ...resolveSelectFields<'SlewFlags'>(info) });
 };

--- a/packages/configs/src/graphql/resolvers/Query/targets.ts
+++ b/packages/configs/src/graphql/resolvers/Query/targets.ts
@@ -1,12 +1,10 @@
+import { resolveSelectFields } from '../query-fields.ts';
 import type { QueryResolvers } from './../../gen/types.generated.ts';
 
-export const targets: NonNullable<QueryResolvers['targets']> = (_parent, args, { prisma }) => {
+export const targets: NonNullable<QueryResolvers['targets']> = (_parent, args, { prisma }, info) => {
   return prisma.target.findMany({
     where: args,
     orderBy: { createdAt: 'desc' },
-    include: {
-      sidereal: true,
-      nonsidereal: true,
-    },
+    ...resolveSelectFields<'Target'>(info),
   });
 };

--- a/packages/configs/src/graphql/resolvers/query-fields.ts
+++ b/packages/configs/src/graphql/resolvers/query-fields.ts
@@ -1,0 +1,82 @@
+/* eslint-disable  */
+import type { GraphQLResolveInfo } from 'graphql';
+import { parseResolveInfo, type ResolveTree } from 'graphql-parse-resolve-info';
+
+import type {
+  AltairGuideLoopSelect,
+  AltairInstrumentSelect,
+  CalParamsSelect,
+  ConfigurationSelect,
+  EngineeringTargetSelect,
+  GemsGuideLoopSelect,
+  GemsInstrumentSelect,
+  GuideAlarmSelect,
+  GuideLoopSelect,
+  InstrumentSelect,
+  MechanismSelect,
+  NonsiderealTargetSelect,
+  RotatorSelect,
+  SiderealTargetSelect,
+  SlewFlagsSelect,
+  TargetSelect,
+} from '../../prisma/gen/models.ts';
+
+// Mapping of all Prisma models to their corresponding select types. This is used to ensure type safety when constructing select objects from GraphQLResolveInfo.
+type ModelSelectMap = {
+  Configuration: ConfigurationSelect;
+  EngineeringTarget: EngineeringTargetSelect;
+  Target: TargetSelect;
+  SiderealTarget: SiderealTargetSelect;
+  NonsiderealTarget: NonsiderealTargetSelect;
+  Instrument: InstrumentSelect;
+  Rotator: RotatorSelect;
+  SlewFlags: SlewFlagsSelect;
+  Mechanism: MechanismSelect;
+  AltairInstrument: AltairInstrumentSelect;
+  GemsInstrument: GemsInstrumentSelect;
+  GuideLoop: GuideLoopSelect;
+  AltairGuideLoop: AltairGuideLoopSelect;
+  GemsGuideLoop: GemsGuideLoopSelect;
+  GuideAlarm: GuideAlarmSelect;
+  CalParams: CalParamsSelect;
+};
+
+type SelectQuery = { select: Record<string, SelectFields> };
+
+type SelectFields = boolean | SelectQuery;
+
+/**
+ * Create a Prisma select object from given GraphQLResolveInfo to only query requested fields.
+ *
+ * Works recursively, as long as the GraphQL model resembles the Prisma model.
+ */
+export function resolveSelectFields<T extends keyof ModelSelectMap>(
+  info: GraphQLResolveInfo,
+): T extends keyof ModelSelectMap ? { select: ModelSelectMap[T] } : { select: undefined } {
+  const parsedInfo = parseResolveInfo(info);
+
+  const extractAllFields = (tree: ResolveTree) => {
+    const result: SelectQuery = { select: {} };
+    for (const typename in tree.fieldsByTypeName) {
+      const fieldsOfType = tree.fieldsByTypeName[typename];
+      for (const key in fieldsOfType) {
+        const fieldInfo = fieldsOfType[key];
+        if (fieldInfo && Object.keys(fieldInfo?.fieldsByTypeName ?? {}).length) {
+          result.select![key] = extractAllFields(fieldInfo);
+        } else {
+          result.select![key] = true;
+        }
+      }
+    }
+    return result;
+  };
+
+  if (parsedInfo && 'fieldsByTypeName' in parsedInfo && Object.keys(parsedInfo.fieldsByTypeName).length) {
+    return extractAllFields(parsedInfo as ResolveTree) as T extends keyof ModelSelectMap
+      ? { select: ModelSelectMap[T] }
+      : { select: undefined };
+  }
+  return { select: undefined } as T extends keyof ModelSelectMap
+    ? { select: ModelSelectMap[T] }
+    : { select: undefined };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       graphql:
         specifier: 16.14.1
         version: 16.14.1
+      graphql-parse-resolve-info:
+        specifier: 4.14.1
+        version: 4.14.1(graphql@16.14.1)
       graphql-scalars:
         specifier: 1.25.0
         version: 1.25.0(graphql@16.14.1)
@@ -2978,6 +2981,12 @@ packages:
     engines: {node: '>=6.0.0'}
     peerDependencies:
       graphql: '*'
+
+  graphql-parse-resolve-info@4.14.1:
+    resolution: {integrity: sha512-WKHukfEuZamP1ZONR84b8iT+4sJgEhtXMDArm1jpXEsU2vTb5EgkCZ4Obfl+v09oNTKXm0CJjPfBUZ5jcJ2Ykg==}
+    engines: {node: '>=8.6'}
+    peerDependencies:
+      graphql: '>=0.9 <0.14 || ^14.0.2 || ^15.4.0 || ^16.3.0'
 
   graphql-scalars@1.25.0:
     resolution: {integrity: sha512-b0xyXZeRFkne4Eq7NAnL400gStGqG/Sx9VqX0A05nHyEbv57UJnWKsjNnrpVqv5e/8N1MUxkt0wwcRXbiyKcFg==}
@@ -7757,6 +7766,14 @@ snapshots:
     dependencies:
       arrify: 1.0.1
       graphql: 16.14.1
+
+  graphql-parse-resolve-info@4.14.1(graphql@16.14.1):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      graphql: 16.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
 
   graphql-scalars@1.25.0(graphql@16.14.1):
     dependencies:


### PR DESCRIPTION
Adds a utility function `resolveSelectFields` that extracts the requested fields from the GraphQL query and transforms them into a shape that can be used in Prisma's `select` options. This allows us to only fetch the data from the database that is actually needed to fulfill the GraphQL query, improving performance.

Example:

Before:

```
prisma:query SELECT "public"."Target"."pk", "public"."Target"."id", "public"."Target"."name", "public"."Target"."magnitude", "public"."Target"."band", "public"."Target"."type"::text, "public"."Target"."wavelength", "public"."Target"."siderealPk", "public"."Target"."nonsiderealPk", "public"."Target"."createdAt" FROM "public"."Target" WHERE 1=1 ORDER BY "public"."Target"."createdAt" DESC OFFSET $1
prisma:query SELECT "public"."SiderealTarget"."pk", "public"."SiderealTarget"."coord1", "public"."SiderealTarget"."coord2", "public"."SiderealTarget"."pmRa", "public"."SiderealTarget"."pmDec", "public"."SiderealTarget"."radialVelocity", "public"."SiderealTarget"."parallax", "public"."SiderealTarget"."epoch", "public"."SiderealTarget"."type"::text, "public"."SiderealTarget"."targetPk" FROM "public"."SiderealTarget" WHERE "public"."SiderealTarget"."targetPk" IN ($1) OFFSET $2
prisma:query SELECT "public"."NonsiderealTarget"."pk", "public"."NonsiderealTarget"."keyType"::text, "public"."NonsiderealTarget"."des", "public"."NonsiderealTarget"."targetPk" FROM "public"."NonsiderealTarget" WHERE "public"."NonsiderealTarget"."targetPk" IN ($1) OFFSET $2
```

After:

```
prisma:query SELECT "public"."Target"."pk", "public"."Target"."name" FROM "public"."Target" WHERE 1=1 ORDER BY "public"."Target"."createdAt" DESC OFFSET $1
prisma:query SELECT "public"."SiderealTarget"."pk", "public"."SiderealTarget"."type"::text, "public"."SiderealTarget"."coord1", "public"."SiderealTarget"."coord2", "public"."SiderealTarget"."pmRa", "public"."SiderealTarget"."pmDec", "public"."SiderealTarget"."targetPk" FROM "public"."SiderealTarget" WHERE "public"."SiderealTarget"."targetPk" IN ($1) OFFSET $2
```