### PR TITLE
Use generated fragment types for timeline data [sc-8902]

### DIFF
--- a/packages/resource-ui/src/features/tonight/Header.tsx
+++ b/packages/resource-ui/src/features/tonight/Header.tsx
@@ -4,9 +4,9 @@
 import { SelectButton, type SelectButtonChangeEvent } from 'primereact/selectbutton';
 import type { JSX } from 'react';
 
-import type { Site } from '../../gql/gen/graphql';
+import type { Site, TelescopeNightTimeline } from '@/types';
+
 import type { TimelineTimeDisplay } from './time';
-import type { TelescopeNightTimeline } from './types';
 
 interface HeaderProps {
   timeline: TelescopeNightTimeline;

--- a/packages/resource-ui/src/features/tonight/Timeline.tsx
+++ b/packages/resource-ui/src/features/tonight/Timeline.tsx
@@ -7,9 +7,8 @@ import { Chart, PlotOptions, Tooltip, XAxis, YAxis } from '@highcharts/react';
 import { XRangeSeries } from '@highcharts/react/series/XRange';
 import type { JSX } from 'react';
 
-import type { TimestampInterval } from '@/types';
+import type { Site, TimestampInterval } from '@/types';
 
-import type { Site } from '../../gql/gen/graphql';
 import type { TimelineTimeDisplay } from './time';
 import { createTimelineChartConfig } from './timelineChartConfig';
 import type { TimelineBlock, TimelineRowData } from './types';

--- a/packages/resource-ui/src/features/tonight/adapters.ts
+++ b/packages/resource-ui/src/features/tonight/adapters.ts
@@ -1,8 +1,9 @@
 /**
  * Adapts GraphQL timeline data into generic timeline rows.
  */
-import type { TelescopeAvailability, TelescopeModeType, TooSupport } from '../../gql/gen/graphql';
-import type { TelescopeNightTimeline, TimelineRowData, TimelineVariant } from './types';
+import type { TelescopeAvailability, TelescopeModeType, TelescopeNightTimeline, TooSupport } from '@/types';
+
+import type { TimelineRowData, TimelineVariant } from './types';
 
 const modeVariants = {
   QUEUE: 'queue',

--- a/packages/resource-ui/src/features/tonight/time.ts
+++ b/packages/resource-ui/src/features/tonight/time.ts
@@ -3,7 +3,7 @@
  */
 import { formatDuration, intervalToDuration } from 'date-fns';
 
-import type { Site } from '../../gql/gen/graphql';
+import type { Site } from '@/types';
 
 const DEMO_NOW = '2026-08-02T00:30:00-10:00';
 

--- a/packages/resource-ui/src/features/tonight/timelineChartConfig.ts
+++ b/packages/resource-ui/src/features/tonight/timelineChartConfig.ts
@@ -6,9 +6,8 @@ import type { XRangeSeries } from '@highcharts/react/series/XRange';
 import type { Options, Point, XrangePointOptionsObject } from 'highcharts';
 import type { ComponentProps } from 'react';
 
-import type { TimestampInterval } from '@/types';
+import type { Site, TimestampInterval } from '@/types';
 
-import type { Site } from '../../gql/gen/graphql';
 import type { TimelineTimeDisplay } from './time';
 import { formatTime, getDurationLabel, getNowTimestamp, getTimestamp } from './time';
 import { timelineChartTheme } from './timelineChartTheme';

--- a/packages/resource-ui/src/features/tonight/types.ts
+++ b/packages/resource-ui/src/features/tonight/types.ts
@@ -3,10 +3,6 @@
  */
 import type { TimestampInterval } from '@/types';
 
-import type { GetTelescopeNightTimelineQuery } from '../../gql/gen/graphql';
-
-export type TelescopeNightTimeline = NonNullable<GetTelescopeNightTimelineQuery['telescopeNightTimeline']>;
-
 export type TimelineVariant =
   | 'queue'
   | 'classical'

--- a/packages/resource-ui/src/gql/telescope.ts
+++ b/packages/resource-ui/src/gql/telescope.ts
@@ -20,40 +20,64 @@ export const TIMESTAMP_INTERVAL_FRAGMENT = graphql(`
   }
 `);
 
+export const TELESCOPE_MODE_STATUS_FRAGMENT = graphql(`
+  fragment TelescopeModeStatusItem on TelescopeModeStatus {
+    site
+    interval {
+      ...TimestampIntervalItem
+    }
+    mode {
+      type
+      programReference
+    }
+  }
+`);
+
+export const TELESCOPE_AVAILABILITY_STATUS_FRAGMENT = graphql(`
+  fragment TelescopeAvailabilityStatusItem on TelescopeAvailabilityStatus {
+    site
+    interval {
+      ...TimestampIntervalItem
+    }
+    availability
+    reason
+    plannedAvailability
+  }
+`);
+
+export const TELESCOPE_TOO_STATUS_FRAGMENT = graphql(`
+  fragment TelescopeTooStatusItem on TelescopeTooStatus {
+    site
+    interval {
+      ...TimestampIntervalItem
+    }
+    tooSupport
+  }
+`);
+
+export const TELESCOPE_NIGHT_TIMELINE_FRAGMENT = graphql(`
+  fragment TelescopeNightTimelineItem on TelescopeNightTimeline {
+    site
+    observingNight
+    displayInterval {
+      ...TimestampIntervalItem
+    }
+    availability {
+      ...TelescopeAvailabilityStatusItem
+    }
+    tooStatus {
+      ...TelescopeTooStatusItem
+    }
+    modes {
+      ...TelescopeModeStatusItem
+    }
+  }
+`);
+
 export const GET_TELESCOPE_NIGHT_TIMELINE = graphql(`
   query getTelescopeNightTimeline($site: Site!, $observingNight: Date!) {
     telescopeNightTimeline(site: $site, observingNight: $observingNight) {
-      site
-      observingNight
-      displayInterval {
-        ...TimestampIntervalItem
-      }
-      availability {
-        interval {
-          ...TimestampIntervalItem
-        }
-        availability
-        reason
-        plannedAvailability
-        site
-      }
-      tooStatus {
-        interval {
-          ...TimestampIntervalItem
-        }
-        tooSupport
-        site
-      }
-      modes {
-        interval {
-          ...TimestampIntervalItem
-        }
-        site
-        mode {
-          type
-          programReference
-        }
-      }
+      ...TelescopeNightTimelineItem
     }
   }
 `);

--- a/packages/resource-ui/src/test/factories.ts
+++ b/packages/resource-ui/src/test/factories.ts
@@ -1,7 +1,16 @@
-import type { TimeSpan, TimestampInterval } from '@/types';
+import type {
+  TelescopeAvailability,
+  TelescopeAvailabilityStatus,
+  TelescopeModeStatus,
+  TelescopeModeType,
+  TelescopeNightTimeline,
+  TelescopeTooStatus,
+  TimeSpan,
+  TimestampInterval,
+  TooSupport,
+} from '@/types';
 
-import type { TelescopeNightTimeline, TimelineBlock, TimelineRowData } from '../features/tonight/types';
-import type { TelescopeAvailability, TelescopeModeType, TooSupport } from '../gql/gen/graphql';
+import type { TimelineBlock, TimelineRowData } from '../features/tonight/types';
 
 const defaultDuration: TimeSpan = {
   __typename: 'TimeSpan',
@@ -21,29 +30,33 @@ const createModeStatus = (
   start: string,
   end: string,
   programReference: string | null = null,
-) => ({
-  __typename: 'TelescopeModeStatus' as const,
-  site: 'GN' as const,
+): TelescopeModeStatus => ({
+  __typename: 'TelescopeModeStatus',
+  site: 'GN',
   interval: createInterval(start, end),
   mode: {
-    __typename: 'TelescopeMode' as const,
+    __typename: 'TelescopeMode',
     type,
     programReference,
   },
 });
 
-const createAvailabilityStatus = (availability: TelescopeAvailability, start: string, end: string) => ({
-  __typename: 'TelescopeAvailabilityStatus' as const,
-  site: 'GN' as const,
+const createAvailabilityStatus = (
+  availability: TelescopeAvailability,
+  start: string,
+  end: string,
+): TelescopeAvailabilityStatus => ({
+  __typename: 'TelescopeAvailabilityStatus',
+  site: 'GN',
   interval: createInterval(start, end),
   availability,
   reason: null,
   plannedAvailability: null,
 });
 
-const createTooStatus = (tooSupport: TooSupport, start: string, end: string) => ({
-  __typename: 'TelescopeTooStatus' as const,
-  site: 'GN' as const,
+const createTooStatus = (tooSupport: TooSupport, start: string, end: string): TelescopeTooStatus => ({
+  __typename: 'TelescopeTooStatus',
+  site: 'GN',
   interval: createInterval(start, end),
   tooSupport,
 });

--- a/packages/resource-ui/src/types.d.ts
+++ b/packages/resource-ui/src/types.d.ts
@@ -1,4 +1,12 @@
 export type {
+  Site,
+  TelescopeAvailability,
+  TelescopeAvailabilityStatusItemFragment as TelescopeAvailabilityStatus,
+  TelescopeModeStatusItemFragment as TelescopeModeStatus,
+  TelescopeModeType,
+  TelescopeNightTimelineItemFragment as TelescopeNightTimeline,
+  TelescopeTooStatusItemFragment as TelescopeTooStatus,
   TimeSpanItemFragment as TimeSpan,
   TimestampIntervalItemFragment as TimestampInterval,
+  TooSupport,
 } from './gql/gen/graphql';


### PR DESCRIPTION
- Export fragment types through @/types
- Update timeline factories
- Remove duplicated GraphQL model definitions